### PR TITLE
fix warning: circular argument reference - webhook

### DIFF
--- a/lib/slackistrano.rb
+++ b/lib/slackistrano.rb
@@ -23,7 +23,7 @@ module Slackistrano
   #
   #
   #
-  def self.post_as_slackbot(team: nil, token: nil, webhook: webhook, payload: {})
+  def self.post_as_slackbot(team: nil, token: nil, webhook: webhook(), payload: {})
     uri = URI(URI.encode("https://#{team}.slack.com/services/hooks/slackbot?token=#{token}&channel=#{payload[:channel]}"))
 
     Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
@@ -34,7 +34,7 @@ module Slackistrano
   #
   #
   #
-  def self.post_as_webhook(team: nil, token: nil, webhook: webhook, payload: {})
+  def self.post_as_webhook(team: nil, token: nil, webhook: webhook(), payload: {})
     params = {'payload' => payload.to_json}
 
     if webhook.nil?


### PR DESCRIPTION
On ruby 2.2.0 there is a warning when using this gem, see https://bugs.ruby-lang.org/issues/10314 for background