### PR TITLE
Customizable title/pretext in attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Optionally, override the other slack settings:
     set :slack_msg_starting,     -> { "#{ENV['USER'] || ENV['USERNAME']} has started deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :rails_env, 'production'}" }
     set :slack_msg_finished,     -> { "#{ENV['USER'] || ENV['USERNAME']} has finished deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :rails_env, 'production'}" }
     set :slack_msg_failed,       -> { "#{ENV['USER'] || ENV['USERNAME']} failed to deploy branch #{fetch :branch} of #{fetch :application} to #{fetch :rails_env, 'production'}" }
+    set :slack_title_starting,   -> { nil }
+    set :slack_title_finished,   -> { nil }
+    set :slack_title_failed,     -> { nil }
 
 **Note**: You may wish to disable one of the notifications if another service (ex:
 Honeybadger) also displays a deploy notification.

--- a/lib/slackistrano/tasks/slack.rake
+++ b/lib/slackistrano/tasks/slack.rake
@@ -1,5 +1,14 @@
 namespace :slack do
   namespace :deploy do
+    def make_attachments(stage, options={})
+      attachments = options.merge({
+        title: fetch(:"slack_title_#{stage}"),
+        pretext: fetch(:"slack_pretext_#{stage}"),
+        text: fetch(:"slack_msg_#{stage}"),
+        mrkdwn_in: [:text, :pretext]
+      }).reject{|k, v| v.nil? }
+      [attachments]
+    end
 
     task :starting do
       if fetch(:slack_run_starting)
@@ -14,12 +23,7 @@ namespace :slack do
               username: fetch(:slack_username),
               icon_url: fetch(:slack_icon_url),
               icon_emoji: fetch(:slack_icon_emoji),
-              attachments: [{
-                  title: fetch(:slack_title_starting),
-                  pretext: fetch(:slack_pretext_starting),
-                  text: fetch(:slack_msg_starting),
-                  mrkdwn_in: [:text, :pretext]
-              }]
+              attachments: make_attachments(:starting)
             }
           )
         end
@@ -39,13 +43,7 @@ namespace :slack do
               username: fetch(:slack_username),
               icon_url: fetch(:slack_icon_url),
               icon_emoji: fetch(:slack_icon_emoji),
-              attachments: [{
-                  color: 'good',
-                  title: fetch(:slack_title_finished),
-                  pretext: fetch(:slack_pretext_finished),
-                  text: fetch(:slack_msg_finished),
-                  mrkdwn_in: [:text, :pretext]
-              }]
+              attachments: make_attachments(:finished, color: 'good')
             }
           )
         end
@@ -65,13 +63,7 @@ namespace :slack do
               username: fetch(:slack_username),
               icon_url: fetch(:slack_icon_url),
               icon_emoji: fetch(:slack_icon_emoji),
-              attachments: [{
-                  color: 'danger',
-                  title: fetch(:slack_title_failed),
-                  pretext: fetch(:slack_pretext_failed),
-                  text: fetch(:slack_msg_failed),
-                  mrkdwn_in: [:text, :pretext]
-              }]
+              attachments: make_attachments(:failed, color: 'danger')
             }
           )
         end

--- a/lib/slackistrano/tasks/slack.rake
+++ b/lib/slackistrano/tasks/slack.rake
@@ -1,4 +1,3 @@
-
 namespace :slack do
   namespace :deploy do
 
@@ -16,6 +15,7 @@ namespace :slack do
               icon_url: fetch(:slack_icon_url),
               icon_emoji: fetch(:slack_icon_emoji),
               attachments: [{
+                  title: fetch(:slack_title_starting),
                   text: fetch(:slack_msg_starting),
                   mrkdwn_in: [:text]
               }]
@@ -40,6 +40,7 @@ namespace :slack do
               icon_emoji: fetch(:slack_icon_emoji),
               attachments: [{
                   color: 'good',
+                  title: fetch(:slack_title_finished),
                   text: fetch(:slack_msg_finished),
                   mrkdwn_in: [:text]
               }]
@@ -64,6 +65,7 @@ namespace :slack do
               icon_emoji: fetch(:slack_icon_emoji),
               attachments: [{
                   color: 'danger',
+                  title: fetch(:slack_title_failed),
                   text: fetch(:slack_msg_failed),
                   mrkdwn_in: [:text]
               }]
@@ -101,5 +103,8 @@ namespace :load do
     set :slack_msg_starting,     -> { "#{ENV['USER'] || ENV['USERNAME']} has started deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :stage, 'an unknown stage'}" }
     set :slack_msg_finished,     -> { "#{ENV['USER'] || ENV['USERNAME']} has finished deploying branch #{fetch :branch} of #{fetch :application} to #{fetch :stage, 'an unknown stage'}" }
     set :slack_msg_failed,       -> { "#{ENV['USER'] || ENV['USERNAME']} failed to deploy branch #{fetch :branch} of #{fetch :application} to #{fetch :stage, 'an unknown stage'}" }
+    set :slack_title_starting,   -> { nil }
+    set :slack_title_finished,   -> { nil }
+    set :slack_title_failed,     -> { nil }
   end
 end

--- a/lib/slackistrano/tasks/slack.rake
+++ b/lib/slackistrano/tasks/slack.rake
@@ -16,8 +16,9 @@ namespace :slack do
               icon_emoji: fetch(:slack_icon_emoji),
               attachments: [{
                   title: fetch(:slack_title_starting),
+                  pretext: fetch(:slack_pretext_starting),
                   text: fetch(:slack_msg_starting),
-                  mrkdwn_in: [:text]
+                  mrkdwn_in: [:text, :pretext]
               }]
             }
           )
@@ -41,8 +42,9 @@ namespace :slack do
               attachments: [{
                   color: 'good',
                   title: fetch(:slack_title_finished),
+                  pretext: fetch(:slack_pretext_finished),
                   text: fetch(:slack_msg_finished),
-                  mrkdwn_in: [:text]
+                  mrkdwn_in: [:text, :pretext]
               }]
             }
           )
@@ -66,8 +68,9 @@ namespace :slack do
               attachments: [{
                   color: 'danger',
                   title: fetch(:slack_title_failed),
+                  pretext: fetch(:slack_pretext_failed),
                   text: fetch(:slack_msg_failed),
-                  mrkdwn_in: [:text]
+                  mrkdwn_in: [:text, :pretext]
               }]
             }
           )
@@ -106,5 +109,8 @@ namespace :load do
     set :slack_title_starting,   -> { nil }
     set :slack_title_finished,   -> { nil }
     set :slack_title_failed,     -> { nil }
+    set :slack_pretext_starting, -> { nil }
+    set :slack_pretext_finished, -> { nil }
+    set :slack_pretext_failed,   -> { nil }
   end
 end

--- a/spec/tasks_spec.rb
+++ b/spec/tasks_spec.rb
@@ -45,7 +45,7 @@ describe Slackistrano do
     ['finished', 'good', 'finished_channel'],
     ['failed', 'danger', 'failed_channel'],
   ].each do |stage, color, channel_for_stage|
-  
+
     it "calls Slackistrano.post with the right arguments for stage=#{stage}, color=#{color}, channel_for_stage=#{channel_for_stage}" do
       set :"slack_run_#{stage}", -> { true }
       set :slack_team,           -> { 'team' }
@@ -60,9 +60,9 @@ describe Slackistrano do
       expected_channel = channel_for_stage || 'channel'
 
       attachment = {
-        text: 'text message', 
+        text: 'text message',
         color: color,
-        mrkdwn_in: [:text]
+        mrkdwn_in: [:text, :pretext]
       }.reject{|k,v| v.nil?}
 
       expect(Slackistrano).to receive(:post).with(


### PR DESCRIPTION
I have added the feature that makes Slack's attachment title/pretext customizable.
We can ignore these settings.

Thanks!